### PR TITLE
New polkawasm target release 0.28.1 fix

### DIFF
--- a/Dockerfile.polkawasm
+++ b/Dockerfile.polkawasm
@@ -1,0 +1,35 @@
+# diffs
+# - prebuild LLVM
+# - WASI platform dependencies (wasi-libc, binaryen /lib submodules)
+
+FROM golang:1.19.5-bullseye AS tinygo-base
+
+ENV GO111MODULE=on
+ENV GOFLAGS="-buildvcs=false"
+
+# Add the LLVM 15 repo for Debian 11 Bullseye
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+  echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main" | tee /etc/apt/sources.list.d/llvm.list
+
+# Install LLVM toolchain packages
+RUN apt-get update && apt-get install -y \
+  clang-15 lld-15 llvm-15-dev libclang-15-dev cmake ninja-build
+
+# Copy TinyGo repo
+COPY . /tinygo
+
+# Update submodule
+RUN cd /tinygo/ && \
+  rm -rf ./lib/*/ && \
+  git submodule sync && \
+  git submodule update --init --recursive --force lib/wasi-libc && \
+  git submodule update --init --recursive --force lib/binaryen
+
+# Build WASI libs, Bynaryen (wasm-opts dependency) and the TinyGo compiler
+RUN cd /tinygo/ && \
+  make wasi-libc binaryen && \
+  go install .
+
+WORKDIR /tinygo
+
+CMD ["tinygo"]

--- a/polkawasm.sh
+++ b/polkawasm.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker build --tag polkawasm/tinygo:0.28.1 -f Dockerfile.polkawasm .
+docker run --rm -it polkawasm/tinygo:0.28.1 bash

--- a/src/os/dir_other.go
+++ b/src/os/dir_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || windows
+//go:build baremetal || js || windows || polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/dir_unix.go
+++ b/src/os/dir_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && !baremetal && !wasi
+//go:build linux && !baremetal && !wasi && !polkawasm
 
 package os
 

--- a/src/os/dirent_linux.go
+++ b/src/os/dirent_linux.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !polkawasm
 
 // Copyright 2020 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/env_unix_test.go
+++ b/src/os/env_unix_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || linux
+//go:build darwin || (linux && !polkawasm)
 
 package os_test
 

--- a/src/os/exec_posix.go
+++ b/src/os/exec_posix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris || windows
+//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || (linux && !polkawasm) || netbsd || openbsd || solaris || windows
 
 package os
 

--- a/src/os/executable_other.go
+++ b/src/os/executable_other.go
@@ -1,4 +1,4 @@
-//go:build !linux || baremetal
+//go:build !linux || baremetal || polkawasm
 
 package os
 

--- a/src/os/executable_procfs.go
+++ b/src/os/executable_procfs.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && !baremetal
+//go:build linux && !baremetal && !polkawasm
 
 package os
 

--- a/src/os/file_anyos.go
+++ b/src/os/file_anyos.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !polkawasm
 
 // Portions copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/file_anyos_test.go
+++ b/src/os/file_anyos_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !polkawasm
 
 package os_test
 

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasi)
+//go:build baremetal || polkawasm || (wasm && !wasi)
 
 package os
 

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal)
+//go:build darwin || (linux && !baremetal && !polkawasm)
 
 // target wasi sets GOOS=linux and thus the +linux build tag,
 // even though it doesn't show up in "tinygo info target -wasi"

--- a/src/os/getpagesize_test.go
+++ b/src/os/getpagesize_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal)
+//go:build windows || darwin || (linux && !baremetal && !polkawasm)
 
 package os_test
 

--- a/src/os/os_anyos_test.go
+++ b/src/os/os_anyos_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal)
+//go:build windows || darwin || (linux && !baremetal && !polkawasm)
 
 package os_test
 

--- a/src/os/os_chmod_test.go
+++ b/src/os/os_chmod_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/os_symlink_test.go
+++ b/src/os/os_symlink_test.go
@@ -1,4 +1,4 @@
-//go:build !windows && !baremetal && !js && !wasi
+//go:build !windows && !baremetal && !js && !wasi && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/pipe_test.go
+++ b/src/os/pipe_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal && !wasi)
+//go:build windows || darwin || (linux && !baremetal && !wasi && !polkawasm)
 
 // Copyright 2021 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/read_test.go
+++ b/src/os/read_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/removeall_noat.go
+++ b/src/os/removeall_noat.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !polkawasm
 
 package os
 

--- a/src/os/removeall_other.go
+++ b/src/os/removeall_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || wasi
+//go:build baremetal || polkawasm || js || wasi
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/removeall_test.go
+++ b/src/os/removeall_test.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal && !js && !wasi)
+//go:build darwin || (linux && !baremetal && !js && !wasi && !polkawasm)
 
 // TODO: implement ReadDir on windows
 

--- a/src/os/seek_unix_bad.go
+++ b/src/os/seek_unix_bad.go
@@ -1,4 +1,4 @@
-//go:build (linux && !baremetal && 386) || (linux && !baremetal && arm && !wasi)
+//go:build (linux && !baremetal && 386) || (linux && !baremetal && arm && !wasi && !polkawasm)
 
 package os
 

--- a/src/os/stat_linux.go
+++ b/src/os/stat_linux.go
@@ -1,4 +1,4 @@
-//go:build linux && !baremetal
+//go:build linux && !baremetal && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_other.go
+++ b/src/os/stat_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasi)
+//go:build baremetal || polkawasm || (wasm && !wasi)
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_unix.go
+++ b/src/os/stat_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal)
+//go:build darwin || (linux && !baremetal && !polkawasm)
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/types_anyos.go
+++ b/src/os/types_anyos.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/types_unix.go
+++ b/src/os/types_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal)
+//go:build darwin || (linux && !baremetal && !polkawasm)
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/runtime/arch_tinygowasm_malloc.go
+++ b/src/runtime/arch_tinygowasm_malloc.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm && !custommalloc
+//go:build tinygo.wasm && !custommalloc && !polkawasm
 
 package runtime
 

--- a/src/runtime/gc_custom.go
+++ b/src/runtime/gc_custom.go
@@ -36,28 +36,161 @@ import (
 	"unsafe"
 )
 
-// initHeap is called when the heap is first initialized at program start.
-func initHeap()
+// const gcDebug = false
+
+// func printnum(num int) {
+// 	digits := [10]int{}
+
+// 	for i := 0; num > 0; i++ {
+// 		digit := num % 10
+// 		digits[i] = digit
+// 		num = num / 10
+// 	}
+
+// 	for i := 0; i < len(digits)/2; i++ {
+// 		j := len(digits) - i - 1
+// 		digits[i], digits[j] = digits[j], digits[i]
+// 	}
+
+// 	skipZeros := true
+// 	for i := 0; i < len(digits); i++ {
+// 		digit := digits[i]
+// 		if skipZeros && digit == 0 {
+// 			continue
+// 		}
+// 		skipZeros = false
+
+// 		digitStr := ""
+
+// 		switch digit {
+// 		case 0:
+// 			digitStr = "0"
+// 		case 1:
+// 			digitStr = "1"
+// 		case 2:
+// 			digitStr = "2"
+// 		case 3:
+// 			digitStr = "3"
+// 		case 4:
+// 			digitStr = "4"
+// 		case 5:
+// 			digitStr = "5"
+// 		case 6:
+// 			digitStr = "6"
+// 		case 7:
+// 			digitStr = "7"
+// 		case 8:
+// 			digitStr = "8"
+// 		case 9:
+// 			digitStr = "9"
+// 		default:
+// 		}
+
+// 		printstr(digitStr)
+// 	}
+// }
+
+// func printstr(str string) {
+// 	if !gcDebug {
+// 		return
+// 	}
+
+// 	for i := 0; i < len(str); i++ {
+// 		if putcharPosition >= putcharBufferSize {
+// 			break
+// 		}
+
+// 		putchar(str[i])
+// 	}
+// }
+
+// Total amount allocated for runtime.MemStats
+var gcTotalAlloc uint64
+
+// Total number of calls to alloc()
+var gcMallocs uint64
+
+// Total number of objected freed; for leaking collector this stays 0
+const gcFrees = 0
+
+// zeroSizedAlloc is just a sentinel that gets returned when allocating 0 bytes.
+var zeroSizedAlloc uint8
 
 // alloc is called to allocate memory. layout is currently not used.
-func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer
+//
+//go:noinline
+func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
+	// printstr("alloc(")
+	// printnum(int(size))
+	// printstr(")\n")
+
+	if size == 0 {
+		// printstr("zero-size allocation\n")
+		return unsafe.Pointer(&zeroSizedAlloc)
+	}
+
+	size = align(size)
+	gcMallocs++
+
+	// try to bound heap growth
+	if gcTotalAlloc+uint64(size) < gcTotalAlloc {
+		// printstr("\tout of memory\n")
+		abort()
+	}
+
+	// allocate memory
+	pointer := extalloc(size)
+	if pointer == nil {
+		// printstr("\textalloc call failed\n")
+		abort()
+	}
+
+	// zero-out the allocated memory
+	memzero(pointer, size)
+	gcTotalAlloc += uint64(size)
+	return pointer
+}
 
 // free is called to explicitly free a previously allocated pointer.
-func free(ptr unsafe.Pointer)
-
-// markRoots is called with the start and end addresses to scan for references.
-// It is currently only called with the top and bottom of the stack.
-func markRoots(start, end uintptr)
+func free(ptr unsafe.Pointer) {
+	extfree(ptr)
+}
 
 // GC is called to explicitly run garbage collection.
-func GC()
+func GC() {
+
+}
 
 // SetFinalizer registers a finalizer.
-func SetFinalizer(obj interface{}, finalizer interface{})
+func SetFinalizer(obj interface{}, finalizer interface{}) {
 
-// ReadMemStats populates m with memory statistics.
-func ReadMemStats(ms *MemStats)
+}
+
+// initHeap is called when the heap is first initialized at program start.
+func initHeap() {
+	// heap is initialized by the external allocator
+}
 
 func setHeapEnd(newHeapEnd uintptr) {
 	// Heap is in custom GC so ignore for when called from wasm initialization.
+}
+
+// markRoots is called with the start and end addresses to scan for references.
+// It is currently only called with the top and bottom of the stack.
+func markRoots(start, end uintptr) {
+
+}
+
+// ReadMemStats populates m with memory statistics.
+func ReadMemStats(ms *MemStats) {
+	ms.HeapIdle = 0
+	ms.HeapInuse = gcTotalAlloc
+	ms.HeapReleased = 0 // always 0, we don't currently release memory back to the OS.
+
+	ms.HeapSys = ms.HeapInuse + ms.HeapIdle
+	ms.GCSys = 0
+	ms.TotalAlloc = gcTotalAlloc
+	ms.Mallocs = gcMallocs
+	ms.Frees = gcFrees
+	ms.Sys = uint64(heapEnd - heapStart)
 }

--- a/src/runtime/os_linux.go
+++ b/src/runtime/os_linux.go
@@ -1,4 +1,4 @@
-//go:build linux && !baremetal && !nintendoswitch && !wasi
+//go:build linux && !baremetal && !nintendoswitch && !wasi && !polkawasm
 
 package runtime
 

--- a/src/runtime/os_other.go
+++ b/src/runtime/os_other.go
@@ -1,4 +1,4 @@
-//go:build linux && (baremetal || nintendoswitch || wasi)
+//go:build linux && (baremetal || nintendoswitch || wasi || polkawasm)
 
 // Other systems that aren't operating systems supported by the Go toolchain
 // need to pretend to be an existing operating system. Linux seems like a good

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -2,17 +2,13 @@
 
 package runtime
 
-import (
-	"unsafe"
-)
-
-//export _start
-func _start() {
-	// These need to be initialized early so that the heap can be initialized.
-	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
-	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
-	run()
-}
+// //export _start
+// func _start() {
+// 	// These need to be initialized early so that the heap can be initialized.
+// 	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
+// 	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
+// 	run()
+// }
 
 // Abort executes the wasm 'unreachable' instruction.
 func abort() {

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -1,0 +1,77 @@
+//go:build polkawasm
+
+package runtime
+
+import (
+	"unsafe"
+)
+
+//export _start
+func _start() {
+	// These need to be initialized early so that the heap can be initialized.
+	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
+	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
+	run()
+}
+
+// Abort executes the wasm 'unreachable' instruction.
+func abort() {
+	trap()
+}
+
+//go:linkname os_runtime_args os.runtime_args
+func os_runtime_args() []string {
+	return []string{}
+}
+
+//go:linkname syscall_runtime_envs syscall.runtime_envs
+func syscall_runtime_envs() []string {
+	return []string{}
+}
+
+func putchar(c byte) {
+}
+
+func getchar() byte {
+	return 0
+}
+
+func buffered() int {
+	return 0
+}
+
+type timeUnit int64
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	panic("unimplemented: ticksToNanoseconds")
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	panic("unimplemented: nanosecondsToTicks")
+}
+
+func sleepTicks(d timeUnit) {
+	panic("unimplemented: sleepTicks")
+}
+
+func ticks() timeUnit {
+	panic("unimplemented: ticks")
+}
+
+//go:linkname now time.now
+func now() (int64, int32, int64) {
+	panic("unimplemented: now")
+}
+
+//go:linkname syscall_Exit syscall.Exit
+func syscall_Exit(code int) {
+	return
+}
+
+//go:linkname procPin sync/atomic.runtime_procPin
+func procPin() {
+}
+
+//go:linkname procUnpin sync/atomic.runtime_procUnpin
+func procUnpin() {
+}

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -2,6 +2,8 @@
 
 package runtime
 
+import "unsafe"
+
 // //export _start
 // func _start() {
 // 	// These need to be initialized early so that the heap can be initialized.
@@ -10,22 +12,28 @@ package runtime
 // 	run()
 // }
 
+// // Using global variables to avoid heap allocation.
+// const putcharBufferSize = 32 * 1024
+
+// var (
+// 	putcharBuffer        = [putcharBufferSize]byte{}
+// 	putcharPosition uint = 0
+// )
+
+// //go:export _debug_buf
+// func debugBuf() uintptr {
+// 	return uintptr(unsafe.Pointer(&putcharBuffer[0]))
+// }
+
 // Abort executes the wasm 'unreachable' instruction.
 func abort() {
 	trap()
 }
 
-//go:linkname os_runtime_args os.runtime_args
-func os_runtime_args() []string {
-	return []string{}
-}
-
-//go:linkname syscall_runtime_envs syscall.runtime_envs
-func syscall_runtime_envs() []string {
-	return []string{}
-}
-
 func putchar(c byte) {
+	// putcharBuffer[putcharPosition] = c
+	// putcharPosition++
+	panic("unimplemented: putchar")
 }
 
 func getchar() byte {
@@ -55,8 +63,18 @@ func ticks() timeUnit {
 }
 
 //go:linkname now time.now
-func now() (int64, int32, int64) {
+func now() (sec int64, nsec int32, mono int64) {
 	panic("unimplemented: now")
+}
+
+//go:linkname syscall_runtime_envs syscall.runtime_envs
+func syscall_runtime_envs() []string {
+	panic("unimplemented: syscall_runtime_envs")
+}
+
+//go:linkname os_runtime_args os.runtime_args
+func os_runtime_args() []string {
+	return []string{}
 }
 
 //go:linkname syscall_Exit syscall.Exit
@@ -66,8 +84,18 @@ func syscall_Exit(code int) {
 
 //go:linkname procPin sync/atomic.runtime_procPin
 func procPin() {
+
 }
 
 //go:linkname procUnpin sync/atomic.runtime_procUnpin
 func procUnpin() {
+
 }
+
+//go:wasm-module env
+//go:export ext_allocator_malloc_version_1
+func extalloc(size uintptr) unsafe.Pointer
+
+//go:wasm-module env
+//go:export ext_allocator_free_version_1
+func extfree(ptr unsafe.Pointer)

--- a/src/runtime/runtime_tinygowasm.go
+++ b/src/runtime/runtime_tinygowasm.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm
+//go:build tinygo.wasm && !polkawasm
 
 package runtime
 

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -1,4 +1,4 @@
-//go:build (darwin || (linux && !baremetal && !wasi)) && !nintendoswitch
+//go:build (darwin || (linux && !baremetal && !wasi && !polkawasm)) && !nintendoswitch
 
 package runtime
 

--- a/src/runtime/runtime_wasm_js.go
+++ b/src/runtime/runtime_wasm_js.go
@@ -1,4 +1,4 @@
-//go:build wasm && !wasi
+//go:build wasm && !wasi && !polkawasm
 
 package runtime
 

--- a/src/runtime/runtime_wasm_js_scheduler.go
+++ b/src/runtime/runtime_wasm_js_scheduler.go
@@ -1,4 +1,4 @@
-//go:build wasm && !wasi && !scheduler.none
+//go:build wasm && !wasi && !polkawasm && !scheduler.none
 
 package runtime
 

--- a/src/runtime/runtime_wasm_wasi.go
+++ b/src/runtime/runtime_wasm_wasi.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm && wasi
+//go:build tinygo.wasm && wasi && !polkawasm
 
 package runtime
 

--- a/src/syscall/file_emulated.go
+++ b/src/syscall/file_emulated.go
@@ -1,4 +1,4 @@
-//go:build baremetal || wasm
+//go:build baremetal || wasm || polkawasm
 
 // This file emulates some file-related functions that are only available
 // under a real operating system.

--- a/src/syscall/file_hosted.go
+++ b/src/syscall/file_hosted.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !wasm
+//go:build !baremetal && !wasm && !polkawasm
 
 // This file assumes there is a libc available that runs on a real operating
 // system.

--- a/src/syscall/proc_emulated.go
+++ b/src/syscall/proc_emulated.go
@@ -1,4 +1,4 @@
-//go:build baremetal || wasi || wasm
+//go:build baremetal || wasi || wasm || polkawasm
 
 // This file emulates some process-related functions that are only available
 // under a real operating system.

--- a/src/syscall/proc_hosted.go
+++ b/src/syscall/proc_hosted.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !wasi && !wasm
+//go:build !baremetal && !wasi && !wasm && !polkawasm
 
 // This file assumes there is a libc available that runs on a real operating
 // system.

--- a/src/syscall/syscall_nonhosted.go
+++ b/src/syscall/syscall_nonhosted.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js
+//go:build baremetal || js || polkawasm
 
 package syscall
 

--- a/src/syscall/tables_nonhosted.go
+++ b/src/syscall/tables_nonhosted.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build baremetal || nintendoswitch || js
+//go:build baremetal || nintendoswitch || js || polkawasm
 
 package syscall
 

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -9,9 +9,10 @@
 	],
 	"goos": "linux",
 	"goarch": "arm",
+	"gc": "conservative",
 	"linker": "wasm-ld",
 	"libc": "wasi-libc",
-	"scheduler": "asyncify",
+	"scheduler": "none",
 	"default-stack-size": 16384,
 	"cflags": [
 		"-mbulk-memory",
@@ -19,8 +20,14 @@
 		"-msign-ext"
 	],
 	"ldflags": [
+		"--initial-memory=1310720",
+		"--no-demangle",
 		"--stack-first",
-		"--no-demangle"
+		"--import-memory",
+		"--allow-undefined",
+		"--export=__heap_base",
+		"--export=__data_end",
+		"--export-table"
 	],
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -1,0 +1,30 @@
+{
+	"llvm-target": "wasm32-unknown-unknown",
+	"cpu": "generic",
+	"features": "+bulk-memory,+nontrapping-fptoint,+sign-ext",
+	"build-tags": [
+		"tinygo.wasm",
+		"polkawasm",
+		"runtime_memhash_leveldb"
+	],
+	"goos": "linux",
+	"goarch": "arm",
+	"linker": "wasm-ld",
+	"libc": "wasi-libc",
+	"scheduler": "asyncify",
+	"default-stack-size": 16384,
+	"cflags": [
+		"-mbulk-memory",
+		"-mnontrapping-fptoint",
+		"-msign-ext"
+	],
+	"ldflags": [
+		"--stack-first",
+		"--no-demangle"
+	],
+	"extra-files": [
+		"src/runtime/asm_tinygowasm.S"
+	],
+	"emulator": "wasmtime {}",
+	"wasm-abi": "generic"
+}

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -1,7 +1,7 @@
 {
 	"llvm-target": "wasm32-unknown-unknown",
 	"cpu": "generic",
-	"features": "+bulk-memory,+nontrapping-fptoint,+sign-ext",
+	"features": "",
 	"build-tags": [
 		"tinygo.wasm",
 		"polkawasm",
@@ -14,11 +14,7 @@
 	"libc": "wasi-libc",
 	"scheduler": "none",
 	"default-stack-size": 16384,
-	"cflags": [
-		"-mbulk-memory",
-		"-mnontrapping-fptoint",
-		"-msign-ext"
-	],
+	"cflags": [],
 	"ldflags": [
 		"--initial-memory=1310720",
 		"--no-demangle",

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -23,11 +23,12 @@
 		"--allow-undefined",
 		"--export=__heap_base",
 		"--export=__data_end",
-		"--export-table"
+		"--export-table",
+		"--no-entry"
 	],
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"
 	],
-	"emulator": "wasmtime {}",
+	"emulator": "wasmtime --mapdir=/tmp::{tmpDir} {}",
 	"wasm-abi": "generic"
 }

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -9,7 +9,7 @@
 	],
 	"goos": "linux",
 	"goarch": "arm",
-	"gc": "conservative",
+	"gc": "custom",
 	"linker": "wasm-ld",
 	"libc": "wasi-libc",
 	"scheduler": "none",


### PR DESCRIPTION
### Changes
🎯  New `polkawasm` target, targeting standalone **Wasm MVP**, similar to Rust's `wasm32-unknown-unknown`, but also incorporating **custom GC** that utilizes an external allocator. Based on Tinygo 0.28.1.

- [x] add custom Dockerfile and build script
- [x] add target implementation separate from the existing `wasm/wasi`
- [x] allow undefined
- [x] export globals and tables
- [x] import memory
- [ ] ~~change stack placement~~(no need, for now)
- [x] disable the scheduler and remove the support of goroutines and channels
- [x] use `wasi-libc` with bulk memory ops disabled [wasi-libc pr](https://github.com/LimeChain/wasi-libc/pull/1) instead of providing own implementation. Not using `-opt=0` drops the size significantly, ~400KB
- [x] remove `_start` export 
- [x] remove `wasm-libc` exported allocation functions
- [x] add custom gc implementation

### Issues
⚠️ With this newer release, most of the [gosemble pr](https://github.com/LimeChain/gosemble/pull/131) tests fail.

- [x] 🔧 this [scale pr](https://github.com/LimeChain/goscale/pull/72) resolves some of the issues

Some tests still fail, depending on the GC used:

**conservative GC**
- [x] 🔧 use greater heap base offset
~~`Test_ApplyExtrinsic_ExhaustsResourcesError`~~
~~`Test_ValidateTransaction_ExhaustsResourcesError`~~

**custom extalloc GC**

* [x] 🔧 issue with `fmt.Sprintf`
~~`Test_BlockExecution`~~
~~`Test_Metadata_Encoding_Success`~~
~~`Test_ApplyExtrinsic_ExhaustsResourcesError`~~

* [x] 🔧 disable the interpretation step which inits some globals
~~`Test_Balances_Transfer_Invalid_ExistentialDeposit`~~
~~`Test_Balances_SetBalance_BadOrigin`~~
~~`Test_Balances_ForceTransfer_BadOrigin`~~
~~`Test_Balances_ForceFree_BadOrigin`~~
